### PR TITLE
Handle return statements that have values

### DIFF
--- a/parser/ast.js
+++ b/parser/ast.js
@@ -643,3 +643,23 @@ util.inherits(AstStructSpecifier, AstNode);
 proto = AstStructSpecifier.prototype;
 
 
+/**
+ * AST Return Statement Class
+ */
+function AstReturnStatement(expression) {
+	AstNode.apply(this);
+	this.primary_expression = expression;
+}
+
+util.inherits(AstReturnStatement, AstNode);
+proto = AstReturnStatement.prototype;
+
+/**
+ * Return string representation of node
+ *
+ * @return  string
+ */
+proto.toString = function() {
+	return util.format("return %s;", this.primary_expression);
+};
+

--- a/parser/grammar.jison
+++ b/parser/grammar.jison
@@ -1203,7 +1203,9 @@ jump_statement:
 			'CONTINUE' ';'
 		|	'BREAK' ';'
 		|	'RETURN' ';'
-		|	'RETURN' expression ';'
+		|	'RETURN' expression ';' {
+                $$ = new AstReturnStatement($2);
+				$$.setLocation(@1); }
 		|	'DISCARD' ';' /* Fragment shader only.*/
 		;
 


### PR DESCRIPTION
Any guidance on this one? I see several problems with it:
- I added AstReturnStatement even though it only applies to statements that return values. Regular returns come out as symbols
- The glsl spec doesn't have a return_statement top level rule, it's jump_statement. Should I make a jump statement node?
- Can this somehow be repurposed with other existing classes already? I don't know how you're implementing the node classes - are you eventually planning to go 1:1 with the full spec?
