### PR TITLE
Fixes parsing of function parameters

### DIFF
--- a/parser/ast.js
+++ b/parser/ast.js
@@ -368,21 +368,27 @@ proto = AstFullySpecifiedType.prototype;
  * @return  string
  */
 proto.toString = function() {
-	var q, qual = "";
+	var q,
+		output = [];
 
-	if (this.qualifier && this.qualifier.flags !== 0) {
+	// If qualifier is an array it has multiple qualifiers, so join them
+	if( Array.isArray( this.qualifier ) ) {
+		output = output.concat( this.qualifier );
+	} else if (this.qualifier && this.qualifier.flags !== 0) {
 		for (q in AstTypeQualifier) {
 			if (AstTypeQualifier.hasOwnProperty(q)) {
 				if (this.qualifier.flags & AstTypeQualifier[q]) {
-					qual += q + " ";
+					output.push(q);
+					break;
 				}
 			}
 		}
 	}
 
-	return qual + this.specifier;
-};
+	output.push( this.specifier );
 
+	return output.join(' ');
+};
 
 /**
  * AST Declaration Class

--- a/parser/grammar.jison
+++ b/parser/grammar.jison
@@ -735,7 +735,10 @@ function_header_with_parameters:
 			  	$$ = $1;
 				$$.parameters.push($2);
 			}
-		| function_header_with_parameters ',' parameter_declaration
+		| function_header_with_parameters ',' parameter_declaration {
+			  	$$ = $1;
+				$$.parameters.push($3);
+        }
 		;
 
 /* Line: 804 */
@@ -752,15 +755,40 @@ function_header:
 
 /* Line: 818 */
 parameter_declarator:
-			type_specifier any_identifier
+			type_specifier any_identifier {
+                $$ = {};
+                $$.type = $1;
+                $$.identifier = $2;
+            }
 		|	type_specifier any_identifier '[' constant_expression ']'
 		;
 
 /* Line: 843 */
 parameter_declaration:
-		  parameter_type_qualifier parameter_qualifier parameter_declarator
-		| parameter_qualifier parameter_declarator
-		| parameter_type_qualifier parameter_qualifier parameter_type_specifier
+		  parameter_type_qualifier parameter_qualifier parameter_declarator {
+				$$ = new AstParameterDeclarator();
+				$$.setLocation(@1);
+				$$.type = new AstFullySpecifiedType();
+				$$.type.qualifier = [ $1, $2 ];
+                $$.type.specifier = $3.type;
+				$$.identifier = $3.identifier;
+            }
+		| parameter_qualifier parameter_declarator {
+				$$ = new AstParameterDeclarator();
+				$$.setLocation(@1);
+				$$.type = new AstFullySpecifiedType();
+				$$.type.qualifier = $1;
+				$$.type.specifier = $2.type;
+				$$.identifier = $2.identifier;
+			}
+		| parameter_type_qualifier parameter_qualifier parameter_type_specifier {
+				$$ = new AstParameterDeclarator();
+				$$.setLocation(@1);
+				$$.type = new AstFullySpecifiedType();
+				$$.type.qualifier = [ $1, $2 ];
+                $$.type.specifier = $3.type;
+				$$.identifier = $3.identifier;
+        }
 		| parameter_qualifier parameter_type_specifier {
 				$$ = new AstParameterDeclarator();
 				$$.setLocation(@1);


### PR DESCRIPTION
Now this beast is parsed correctly:

Input:

```
float test( const in vec3 a, out mat4 b, inout float c, vec2 d ) {
    return dProd + 1.0;
}
```

Output:

```
float test(const in vec3 a,out mat4 b,inout float c, vec2 d) 
{
return (dProd + 1.0);}
```
