### PR TITLE
Adding truthy check for variable that errors when parsing max()

### DIFF
--- a/parser/symbol.js
+++ b/parser/symbol.js
@@ -210,7 +210,7 @@ proto.get_entry = function(name, typedef, def) {
 	t = this.table[name] || [];
 	for (i = 0; i < t.length; i++) {
 		entry = t[i];
-		if (entry.typedef === typedef && (typedef !== SymbolTableEntry.typedef.func || def.join(',') === entry.definition.join(','))) {
+		if (entry.typedef === typedef && (typedef !== SymbolTableEntry.typedef.func || (def && def.join(',') === entry.definition.join(',')))) {
 			return entry;
 		}
 	}


### PR DESCRIPTION
I'm not sure what the case is behind this, but I'm seeing the parser
error because it's trying to call def.join() when def is undefined. When
inspecting what state the parser is in during this error, it appears to
be trying to inspect a function call in the glsl source "max" as in
"max( 1.0, 2.0 )"
