### PR TITLE
Fixing compiling of comma separated statements

### DIFF
--- a/parser/ast.js
+++ b/parser/ast.js
@@ -106,7 +106,8 @@ var ast_operators = [
 	"&&",
 	"^^",
 	"||",
-	"!",		
+	"!",
+	",",
 	"*=",
 	"/=",
 	"%=",
@@ -358,6 +359,10 @@ proto.toString = function() {
 		
 		case 'bool':
 			output = util.format("%s", this.primary_expression.bool_constant == 'true' ? 'true' : 'false');
+			break;
+
+		case ',':
+			output = this.expressions.join(", ");
 			break;
 
 	}


### PR DESCRIPTION
I found that this code:

```
a.x = 1, b.x = 2;
```

Gets compiled to:

```
,;
```

This is because the comma was not recognized as a valid operator type.
It's set to comma in parser/grammar.jison on line 430:

```
$$ = new AstExpression($2);
```

Where $2 is the comma:

```
    | expression ',' assignment_expression {
```

This small change appears to fix it. Also updated mocha-tests branch to
add test for this
